### PR TITLE
Add support for API authentication using bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ sails-generate-auth, by default doesn't deny access to controllers if the user i
   }
 ```
 
-This helps to restrict access all the controllers except auth controllers such as login, logout and register, if the user is not logged in. See this [issue](https://github.com/kasperisager/sails-generate-auth/issues/112) and [stackoverflow answer](http://stackoverflow.com/questions/27168229/passport-authentication-not-working-in-sails-js-application/27182970#27182970) for more details.
+This helps to restrict access to all the controller except auth controller actions such as login, logout and register, if the user is not logged in. See this [issue](https://github.com/kasperisager/sails-generate-auth/issues/112) and [stackoverflow answer](http://stackoverflow.com/questions/27168229/passport-authentication-not-working-in-sails-js-application/27182970#27182970) for more details.
+
+For controller actions which are accessed via APIs, you can add `bearerAuth` (available in `api/policies`). This policy ensures that the API is secure and only requests containing a bearer token can access them.
 
 ### Questions?
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,9 @@ module.exports = {
     // Passport middleware
     './api/policies/passport.js': { template: 'api/policies/passport.js' },
 
+    // Bearer Authentication Policy
+    './api/policies/bearerAuth.js': { template: 'api/policies/bearerAuth.js' },
+
     // Passport wrapper
     './api/services/passport.js': { template: 'api/services/passport.js' },
 
@@ -42,6 +45,7 @@ module.exports = {
     './api/services/protocols/oauth.js': { template: 'api/services/protocols/oauth.js' },
     './api/services/protocols/oauth2.js': { template: 'api/services/protocols/oauth2.js' },
     './api/services/protocols/openid.js': { template: 'api/services/protocols/openid.js' },
+    './api/services/protocols/bearer.js': { template: 'api/services/protocols/bearer.js' },
 
     // Passport configuration
     './config/passport.js': { template: 'config/passport.js' },

--- a/templates/api/models/Passport.js
+++ b/templates/api/models/Passport.js
@@ -41,11 +41,15 @@ var Passport = {
     // party service (e.g. 'oauth', 'oauth2', 'openid').
     protocol: { type: 'alphanumeric', required: true },
 
-    // Local field: Password
+    // Local fields: Password, Access Token
     //
     // When the local strategy is employed, a password will be used as the
     // means of authentication along with either a username or an email.
-    password: { type: 'string', minLength: 8 },
+    //
+    // accessToken is used to authenticate API requests. it is generated when a 
+    // passport (with protocol 'local') is created for a user. 
+    password    : { type: 'string', minLength: 8 },
+    accessToken : { type: 'string' },
 
     // Provider fields: Provider, identifer and tokens
     //

--- a/templates/api/policies/bearerAuth.js
+++ b/templates/api/policies/bearerAuth.js
@@ -1,0 +1,19 @@
+/**
+ * bearerAuth Policy
+ * 
+ * Policy for authorizing API requests. The request is authenticated if the 
+ * it contains the accessToken in header, body or as a query param.
+ * Unlike other strategies bearer doesn't require a session.
+ * Add this policy (in config/policies.js) to controller actions which are not
+ * accessed through a session. For example: API request from another client
+ *
+ * @param {Object}   req
+ * @param {Object}   res
+ * @param {Function} next
+ */
+
+module.exports = function (req, res, next) {
+
+  return passport.authenticate('bearer', { session: false })(req, res, next);
+  
+};

--- a/templates/api/services/passport.js
+++ b/templates/api/services/passport.js
@@ -292,6 +292,25 @@ passport.loadStrategies = function () {
 
         self.use(new Strategy(options, self.protocols.local.login));
       }
+    } else if (key === 'bearer') {
+      
+      if (strategies.bearer) {
+        Strategy = strategies[key].strategy;
+        self.use(new Strategy(function(token, done) {
+        
+          Passport.findOne({ accessToken: token }, function(err, passport) {
+            if (err) { return done(err); }
+            if (!passport) { return done(null, false); }
+            User.findById(passport.user, function(err, user) {
+              if (err) { return done(err); }
+              if (!user) { return done(null, false); }
+              return done(null, user, { scope: 'all' });
+            });
+          });
+        
+        }));
+      }
+      
     } else {
       var protocol = strategies[key].protocol
         , callback = strategies[key].callback;

--- a/templates/api/services/passport.js
+++ b/templates/api/services/passport.js
@@ -1,3 +1,4 @@
+
 var path     = require('path')
   , url      = require('url')
   , passport = require('passport');
@@ -296,19 +297,7 @@ passport.loadStrategies = function () {
       
       if (strategies.bearer) {
         Strategy = strategies[key].strategy;
-        self.use(new Strategy(function(token, done) {
-        
-          Passport.findOne({ accessToken: token }, function(err, passport) {
-            if (err) { return done(err); }
-            if (!passport) { return done(null, false); }
-            User.findById(passport.user, function(err, user) {
-              if (err) { return done(err); }
-              if (!user) { return done(null, false); }
-              return done(null, user, { scope: 'all' });
-            });
-          });
-        
-        }));
+        self.use(new Strategy(self.protocols.bearer.authorize));
       }
       
     } else {

--- a/templates/api/services/protocols/bearer.js
+++ b/templates/api/services/protocols/bearer.js
@@ -1,0 +1,23 @@
+/*
+ * Bearer Authentication Protocol
+ *
+ * Bearer Authentication is for authorizing API requests. Once
+ * a user is created, a token is also generated for that user
+ * in its passport. This token can be used to authenticate
+ * API requests.
+ *
+ */
+
+exports.authorize = function(token, done) {
+  
+  Passport.findOne({ accessToken: token }, function(err, passport) {
+    if (err) { return done(err); }
+    if (!passport) { return done(null, false); }
+    User.findById(passport.user, function(err, user) {
+      if (err) { return done(err); }
+      if (!user) { return done(null, false); }
+      return done(null, user, { scope: 'all' });
+    });
+  });
+  
+};

--- a/templates/api/services/protocols/index.js
+++ b/templates/api/services/protocols/index.js
@@ -16,4 +16,5 @@ module.exports = {
 , oauth  : require('./oauth')
 , oauth2 : require('./oauth2')
 , openid : require('./openid')
+, bearer : require('./bearer')  
 };

--- a/templates/api/services/protocols/local.js
+++ b/templates/api/services/protocols/local.js
@@ -58,10 +58,15 @@ exports.register = function (req, res, next) {
       return next(err);
     }
 
+    // Generating accessToken for API authentication by encoding username and
+    // created at time using base64
+    var token = new Buffer(user.username + user.createdAt).toString('base64');
+
     Passport.create({
-      protocol : 'local'
-    , password : password
-    , user     : user.id
+      protocol    : 'local'
+    , password    : password
+    , user        : user.id
+    , accessToken : token
     }, function (err, passport) {
       if (err) {
         if (err.code === 'E_VALIDATION') {

--- a/templates/api/services/protocols/local.js
+++ b/templates/api/services/protocols/local.js
@@ -1,4 +1,5 @@
 var validator = require('validator');
+var crypto    = require('crypto');
 
 /**
  * Local Authentication Protocol
@@ -58,9 +59,8 @@ exports.register = function (req, res, next) {
       return next(err);
     }
 
-    // Generating accessToken for API authentication by encoding username and
-    // created at time using base64
-    var token = new Buffer(user.username + user.createdAt).toString('base64');
+    // Generating accessToken for API authentication
+    var token = crypto.randomBytes(48).toString('base64');
 
     Passport.create({
       protocol    : 'local'

--- a/templates/config/passport.js
+++ b/templates/config/passport.js
@@ -19,6 +19,10 @@ module.exports.passport = {
     strategy: require('passport-local').Strategy
   },
 
+  bearer: {
+    strategy: require('passport-http-bearer').Strategy
+  },
+
   twitter: {
     name: 'Twitter',
     protocol: 'oauth',


### PR DESCRIPTION
We've added support for API authentication for local strategy using [sails-http-bearer](https://github.com/jaredhanson/passport-http-bearer) module. This is done by adding a new field called `accessToken` in Passport model and generating it automatically while creating a local Passport.

We did that as part of our open source project for mobile device management, [One MDM](https://github.com/multunus/one-mdm/). You can see a working example here: [One MDM Server](http://onemdm.multunus.com/). Login using username `admin` and password `adminadmin`. Get the access token from settings page (top right) and try sending a POST request to [http://onemdm.multunus.com/device/create](http://onemdm.multunus.com/device/create) having params { device: "Some Device Name" } with and without `access_token`. If the request is valid, it will create a new device with the given name in the Devices page. sails-http-bearer allows you to add access_token in 3 ways:

* as a header field (Example: `Authorization: Bearer eWVkaHVUaHUgRGVjIDA0IDIwMTQgMDk6MDg6MjcgR01UKzAwMDAgKFVUQyk=`)
* as a param (Example: `access_token: eWVkaHVUaHUgRGVjIDA0IDIwMTQgMDk6MDg6MjcgR01UKzAwMDAgKFVUQyk=`)
* as a query param

I know that this code can be refactored. But this serves the basic purpose. We put some effort to add API authentication (because most of our APIs are accessed from android devices) and we would like to give it back to the community of sails-generate-auth.

Thanks :)