### PR TITLE
Add support for Central Authentication Service (CAS)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,7 @@ module.exports = {
     './api/services/protocols/oauth.js': { template: 'api/services/protocols/oauth.js' },
     './api/services/protocols/oauth2.js': { template: 'api/services/protocols/oauth2.js' },
     './api/services/protocols/openid.js': { template: 'api/services/protocols/openid.js' },
+    './api/services/protocols/cas.js': { template: 'api/services/protocols/cas.js' },
 
     // Passport configuration
     './config/passport.js': { template: 'config/passport.js' },

--- a/templates/api/services/protocols/cas.js
+++ b/templates/api/services/protocols/cas.js
@@ -1,0 +1,18 @@
+/**
+ * Central Authentication Service (CAS) Authentication Protocol
+ *
+ * CAS is a single sign-on protocol meant to give a user access to
+ * more than one application by only submitting their credentials once.
+ *
+ * @param {Object}   req
+ * @param {string}   identifier
+ * @param {Function} next
+ */
+module.exports = function (req, identifier, next) {
+  var query    = {
+    identifier : identifier
+  , protocol   : 'cas'
+  };
+
+  passport.connect(req, query, {username: identifier}, next);
+};

--- a/templates/api/services/protocols/index.js
+++ b/templates/api/services/protocols/index.js
@@ -16,4 +16,5 @@ module.exports = {
 , oauth  : require('./oauth')
 , oauth2 : require('./oauth2')
 , openid : require('./openid')
+, cas    : require('./cas')
 };

--- a/templates/config/passport.js
+++ b/templates/config/passport.js
@@ -57,5 +57,16 @@ module.exports.passport = {
       clientID: 'your-client-id',
       clientSecret: 'your-client-secret'
     }
+  },
+
+  cas: {
+    name: 'CAS',
+    protocol: 'cas',
+    strategy: require('passport-cas').Strategy,
+    options: {
+      ssoBaseURL: 'http://your-cas-url',
+      serverBaseURL: 'http://localhost:1337',
+      serviceURL: 'http://localhost:1337/auth/cas/callback'
+    }
   }
 };


### PR DESCRIPTION
I have added support for the Central Authentication Service (CAS) protocol. It is meant to be used with [sadne/passport-cas](https://github.com/sadne/passport-cas).

Let me know if there are any issues!