### PR TITLE
Email scope is essentially required, so specify it

### DIFF
--- a/templates/config/passport.js
+++ b/templates/config/passport.js
@@ -49,7 +49,8 @@ module.exports.passport = {
     strategy: require('passport-facebook').Strategy,
     options: {
       clientID: 'your-client-id',
-      clientSecret: 'your-client-secret'
+      clientSecret: 'your-client-secret',
+      scope: ['email'] /* email is necessary for login behavior */
     }
   },
 


### PR DESCRIPTION
Including the email scope in the default config will fix the confusion expressed in #145, #116, #101, #100, etc. While not required for login behavior in all frameworks/scenarios, it seems a reasonable default given the current requirements of this framework.