### PR TITLE
Fixes bug introduced by the fact that find method returns an array by replacing findById with findOneById

### DIFF
--- a/templates/api/services/protocols/bearer.js
+++ b/templates/api/services/protocols/bearer.js
@@ -13,7 +13,7 @@ exports.authorize = function(token, done) {
   Passport.findOne({ accessToken: token }, function(err, passport) {
     if (err) { return done(err); }
     if (!passport) { return done(null, false); }
-    User.findById(passport.user, function(err, user) {
+    User.findOneById(passport.user, function(err, user) {
       if (err) { return done(err); }
       if (!user) { return done(null, false); }
       return done(null, user, { scope: 'all' });


### PR DESCRIPTION
In sails 0.11 `findById` returns and array. 
The check fails because `![]` is always `false`, no matter what the array is.
```js
      if (!user) { return done(null, false); }
```

One might expect to be able to access the user model by `req.user` instead of `req.user[0]`